### PR TITLE
fix: drop sudo req, better env var handling, bump default syft version

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -3,9 +3,13 @@ parameters:
   caching:
     type: boolean
     default: true
+  install_path:
+    type: string
+    default: "/home/circleci/bin"
+    description: Path to a binary directory not requiring root access (no trailing slash).
   version:
     type: string
-    default: "1.0.1"
+    default: "1.10.0"
     description: Specify the semver of the Syft version to install.
 steps:
   - when:
@@ -16,6 +20,7 @@ steps:
   - run:
       name: Install Syft
       environment:
+        PARAM_INSTALL_PATH: << parameters.install_path >>
         PARAM_VERSION: << parameters.version >>
       command: << include(scripts/install.sh) >>
   - when:

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -2,84 +2,9 @@
 
 set -e
 
-# Check to see if there are any environment variables within another environment
-# variable, and if so, expand them. This allows environment variables to be passed
-# as arguments to CircleCI orbs, which often don't interpret those variables correctly.
-# Although this function seems complex, it's safer than doing: VAR=$(eval echo "${VAR}")
-# and is less susceptible to command injection.
-#   - Supported: ${VARIABLE}
-#   - Unsupported: $VARIABLE
-expand_circleci_env_vars() {
-    search_substring=${1}
-    result=""
-
-    regex="([^}]*)[$]\{([a-zA-Z_]+[a-zA-Z0-9_]*)\}(.*)"
-    while [[ $search_substring =~ $regex ]]; do
-        prefix=${BASH_REMATCH[1]}
-        match=${BASH_REMATCH[2]}
-        suffix=${BASH_REMATCH[3]}
-
-        # if the environment variable exists, evaluate it, but
-        # guard against infinite recursion. e.g., MYVAR="\$MYVAR"
-        if [[ -n ${!match} ]] && [[ "${!match}" != "\${${match}}" ]]; then
-            repaired="${prefix}${!match}"
-            result="${result}${repaired}"
-            search_substring="${suffix}"
-        else
-            result="${result}${prefix}"
-            search_substring="${suffix}"
-        fi
-    done
-
-    midpoint_result="${result}${search_substring}"
-    search_substring="${result}${search_substring}"
-    result=""
-    env_var_present=false
-
-    # Handle the non-squiggley brace syntax: $VARIABLE.
-    regex="([^$]*)[$]([a-zA-Z_]+[a-zA-Z0-9_]*)(.*)"
-    while [[ $search_substring =~ $regex ]]; do
-        prefix=${BASH_REMATCH[1]}
-        match=${BASH_REMATCH[2]}
-        suffix=${BASH_REMATCH[3]}
-
-        # if the environment variable exists, evaluate it, but
-        # guard against infinite recursion. e.g., MYVAR="\$MYVAR"
-        if [[ -n ${!match} ]] && [[ "${!match}" != "\$${match}" ]]; then
-            repaired="${prefix}${!match}"
-            result="${result}${repaired}"
-            search_substring="${suffix}"
-            env_var_present=true
-        else
-            # If completely unset and not just an empty value, just leave it be
-            # to deal with inadequacies of aggressive mode. If the variable is
-            # actually present, but has an empty value, replace it with "".
-            if [[ -z ${!match+x} ]]; then
-                result="${result}${prefix}\$${match}"
-            else
-                result="${result}${prefix}"
-                env_var_present=true
-            fi
-
-            search_substring="${suffix}"
-        fi
-    done
-    result="${result}${search_substring}"
-
-    # If we can't find at least one environment variable, this field
-    # may have been intended for some other purprose and just happened
-    # to contain a question mark and resembled an environment variable.
-    # Toss out anything we did in the second stage when this happens.
-    if [[ $env_var_present != true ]]; then
-        result=${midpoint_result}
-    fi
-
-    echo "${result}"
-    return 0
-}
-
 # Ensure CircleCI environment variables can be passed in as orb parameters
-PARAM_VERSION=$(expand_circleci_env_vars "${PARAM_VERSION}")
+INSTALL_PATH=$(circleci env subst "${PARAM_INSTALL_PATH}")
+VERSION=$(circleci env subst "${PARAM_VERSION}")
 
 # Check if the syft tar file was in the CircleCI cache.
 # Cache restoration is handled in install.yml
@@ -90,12 +15,12 @@ fi
 # If there was no cache hit, go ahead and re-download the binary.
 # Tar it up to save on cache space used.
 if [[ ! -f syft ]]; then
-    wget "https://github.com/anchore/syft/releases/download/v${PARAM_VERSION}/syft_${PARAM_VERSION}_linux_amd64.tar.gz" -O syft.tar.gz
+    wget "https://github.com/anchore/syft/releases/download/v${VERSION}/syft_${VERSION}_linux_amd64.tar.gz" -O syft.tar.gz
     tar xvzf syft.tar.gz syft
 fi
 
 # A syft binary should exist at this point, regardless of whether it was obtained
 # through cache or re-downloaded. Move it to an appropriate bin directory and mark it
 # as executable.
-sudo mv syft /usr/local/bin/syft
-sudo chmod +x /usr/local/bin/syft
+mv syft "${INSTALL_PATH}/syft"
+chmod +x "${INSTALL_PATH}/syft"


### PR DESCRIPTION
- Remove sudo requirement by installing to a different directory by default. For `cimg/*` base images, install to `/home/circleci/bin` instead of `/usr/local/bin`. The new directory is already present in the `$PATH`. Made the install directory customizable.

- Better handling of environment variable expansion through the use of `circleci env subst`.

- Bump default Syft version from 1.0.1 to 1.10.0. The caller can still specify any version they'd like as an argument.